### PR TITLE
Introduce configurable RECORD mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,30 @@ Clone this repository and run::
   tox
 
 This will install the required packages and run the tests for the
-library.
+library. Installing ``tox`` removes the need to install or use
+``virtualenv`` since tox manages virtual environments already.
 
-We also use `flake8` to ensure we catch Python version differences and
+By default the tests will replay back previously recorded API
+interactions. To affect how tests interact with the Helium API you will have to
+
+* Set a ``HELIUM_API_KEY`` environment variable to a valid Helium API
+  key. For example in ``bash``::
+
+      export HELIUM_API_KEY=<my api key>
+
+* Set ``HELIUM_RECORD_MODE`` to one of:
+
+  ``none``
+      (default) Only play back recorded API interactions.
+
+  ``once``
+      Only record interactions for which no recording exist. If you
+      get an error message from betamax complaining about a recording
+      not matching an interaction that means that your test has new
+      API interactions with it. Remove the cassette referred to in the
+      error message and run the test again to re-generate it .
+
+We use `flake8` to ensure we catch Python version differences and
 common pitfalls quicker. Please run::
 
   tox -e lint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,15 +10,13 @@ import helium
 
 Betamax.register_serializer(pretty_json.PrettyJSONSerializer)
 Betamax.register_request_matcher(json_body.JSONBodyMatcher)
-if os.environ.get('TRAVIS'):
-    API_TOKEN = 'X' * 10
-else:
-    API_TOKEN = os.environ.get('HELIUM_TEST_API_KEY')
-    assert API_TOKEN, 'Please set HELIUM_TEST_API_KEY to a valid API key'
+API_TOKEN = os.environ.get('HELIUM_API_KEY', 'X' * 10)
+RECORD_MODE = os.environ.get('HELIUM_RECORD_MODE', 'none')
+
 
 with Betamax.configure() as config:
     config.cassette_library_dir = 'tests/cassettes'
-    record_mode = 'none' if os.environ.get('TRAVIS') else 'once'
+    record_mode = RECORD_MODE
     cassette_options = config.default_cassette_options
     cassette_options['record_mode'] = record_mode
     cassette_options['serialize_with'] = 'prettyjson'


### PR DESCRIPTION
Records api interactions are now configurable. Also makes the API key optional