### PR TITLE
Add kwargs to Timeseries constuctor

### DIFF
--- a/helium/timeseries.py
+++ b/helium/timeseries.py
@@ -118,7 +118,8 @@ class Timeseries(Iterable):
                  end=None,
                  agg_size=None,
                  agg_type=None,
-                 port=None):
+                 port=None,
+                 **kwargs):
         """Constrct a timeseries.
 
         Args:


### PR DESCRIPTION
Add `**kwargs` to the constructor of `Timeseries` to avoid `TypeError: __init__() got an unexpected keyword argument 'foo'` errors.