### PR TITLE
Don't pop attributes on resource creation

### DIFF
--- a/helium/resource.py
+++ b/helium/resource.py
@@ -348,7 +348,7 @@ class Resource(Base):
         # promote id
         self.id = json.get('id', None)
         # promote all top level attributes
-        for (k, v) in iteritems(json.pop('attributes', {})):
+        for (k, v) in iteritems(json.get('attributes', {})):
             self._promote_json_attribute(k, v)
         # process includes if specified
         if self._include is not None:


### PR DESCRIPTION
Since the attribute dictionary can be shared across multiple
instantiation calls we can't pop it during creation since we don't
technically own those attributes.

We leave the relationships pop alone for now since we haven't found a
case where that is shared quite yet.